### PR TITLE
add tstr support for pre_image_content_type

### DIFF
--- a/draft-ietf-cose-hash-envelope.md
+++ b/draft-ietf-cose-hash-envelope.md
@@ -192,7 +192,7 @@ IANA is requested to add the following entries to the [COSE Header Algorithm Par
 - Value type: uint / tstr
 - Value registry when `uint` is used: https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats
 - Description: The content format associated with the bytes that were hashed to produce the payload.
-  `int` payload_preimage_content_types SHOULD be registered in the content-formats registry.
+  `uint` payload_preimage_content_types SHOULD be registered in the content-formats registry.
   `str` values MAY be used when registered values may not yet be registered.
 
 ### Payload Location

--- a/draft-ietf-cose-hash-envelope.md
+++ b/draft-ietf-cose-hash-envelope.md
@@ -107,7 +107,7 @@ Hash_Envelope_Protected_Header = {
     ; (content to be hashed) of the payload
     ; 50 for application/json,
     ; See https://datatracker.ietf.org/doc/html/rfc7252#section-12.3
-    &(payload_preimage_content_type: TBD_2) => int
+    &(payload_preimage_content_type: TBD_2) => int / tstr
 
     ; Location the content of the hashed payload is stored
     ; For example:
@@ -207,9 +207,11 @@ IANA is requested to add the following entries to the [COSE Header Algorithm Par
 
 - Name: payload_preimage_content_type
 - Label: TBD_2
-- Value type: int
-- Value registry: https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats
+- Value type: int / tstr
+- Value registry when `int` is used: https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats
 - Description: The content format associated with the bytes that were hashed to produce the payload.
+  `int` payload_preimage_content_types SHOULD be registered in the content-formats registry.
+  `str` values MAY be used when registered values may not yet be registered.
 
 ### Payload Location
 

--- a/draft-ietf-cose-hash-envelope.md
+++ b/draft-ietf-cose-hash-envelope.md
@@ -189,7 +189,7 @@ IANA is requested to add the following entries to the [COSE Header Algorithm Par
 
 - Name: payload_preimage_content_type
 - Label: TBD_2
-- Value type: int / tstr
+- Value type: uint / tstr
 - Value registry when `uint` is used: https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats
 - Description: The content format associated with the bytes that were hashed to produce the payload.
   `int` payload_preimage_content_types SHOULD be registered in the content-formats registry.

--- a/draft-ietf-cose-hash-envelope.md
+++ b/draft-ietf-cose-hash-envelope.md
@@ -190,7 +190,7 @@ IANA is requested to add the following entries to the [COSE Header Algorithm Par
 - Name: payload_preimage_content_type
 - Label: TBD_2
 - Value type: int / tstr
-- Value registry when `int` is used: https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats
+- Value registry when `uint` is used: https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats
 - Description: The content format associated with the bytes that were hashed to produce the payload.
   `int` payload_preimage_content_types SHOULD be registered in the content-formats registry.
   `str` values MAY be used when registered values may not yet be registered.

--- a/draft-ietf-cose-hash-envelope.md
+++ b/draft-ietf-cose-hash-envelope.md
@@ -181,7 +181,7 @@ IANA is requested to add the following entries to the [COSE Header Algorithm Par
 
 - Name: payload_hash_alg
 - Label: TBD_1
-- Value type: uint
+- Value type: int
 - Value registry: https://www.iana.org/assignments/cose/cose.xhtml#algorithms
 - Description: Hash algorithm used to produce the payload from pre-image content
 

--- a/draft-ietf-cose-hash-envelope.md
+++ b/draft-ietf-cose-hash-envelope.md
@@ -193,7 +193,7 @@ IANA is requested to add the following entries to the [COSE Header Algorithm Par
 - Value registry when `uint` is used: https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#content-formats
 - Description: The content format associated with the bytes that were hashed to produce the payload.
   `uint` payload_preimage_content_types SHOULD be registered in the content-formats registry.
-  `str` values MAY be used when registered values may not yet be registered.
+  `tstr` values MAY be used when registered values may not yet be registered.
 
 ### Payload Location
 

--- a/draft-ietf-cose-hash-envelope.md
+++ b/draft-ietf-cose-hash-envelope.md
@@ -93,9 +93,9 @@ TBD_3:
 ~~~ cddl
 Hash_Envelope_Protected_Header = {
     ? &(alg: 1) => int,
-    ? &(typ: 16) => int / tstr
-    &(payload_hash_alg: TBD_1) => int
-    &(payload_preimage_content_type: TBD_2) => int / tstr
+    ? &(typ: 16) => uint / tstr
+    &(payload_hash_alg: TBD_1) => uint
+    &(payload_preimage_content_type: TBD_2) => uint / tstr
     ? &(payload_location: TBD_3) => tstr
     * int / tstr => any
 }
@@ -181,7 +181,7 @@ IANA is requested to add the following entries to the [COSE Header Algorithm Par
 
 - Name: payload_hash_alg
 - Label: TBD_1
-- Value type: int
+- Value type: uint
 - Value registry: https://www.iana.org/assignments/cose/cose.xhtml#algorithms
 - Description: Hash algorithm used to produce the payload from pre-image content
 

--- a/draft-ietf-cose-hash-envelope.md
+++ b/draft-ietf-cose-hash-envelope.md
@@ -94,7 +94,7 @@ TBD_3:
 Hash_Envelope_Protected_Header = {
     ? &(alg: 1) => int,
     ? &(typ: 16) => uint / tstr
-    &(payload_hash_alg: TBD_1) => uint
+    &(payload_hash_alg: TBD_1) => int
     &(payload_preimage_content_type: TBD_2) => uint / tstr
     ? &(payload_location: TBD_3) => tstr
     * int / tstr => any


### PR DESCRIPTION
Makes pre_image_content_type consistent with typ: https://www.rfc-editor.org/rfc/rfc9596.html#section-1-2