### PR TITLE
Add missing verb

### DIFF
--- a/draft-ietf-cose-hash-envelope.md
+++ b/draft-ietf-cose-hash-envelope.md
@@ -160,7 +160,7 @@ The signature is produced using ES384 which means using ECDSA with SHA384 hash f
 
 This example is chosen to highlight that an existing system may use a hash algorithm such as sha256.
 This hash becomes the payload of a COSE-Sign1.
-When signed with a signature algorithm that is parameterized via a hash function, such as ECDSA with SHA384, the to be signed structure as described in Section 4.4 of RFC9052.
+When signed with a signature algorithm that is parameterized via a hash function, such as ECDSA with SHA384, the to be signed structure is as described in Section 4.4 of RFC9052.
 
 The resulting signature is computed over the protected header and payload, providing integrity and authenticity for the hash algorithm, content type and location of the associated resource, in this case a software bill of materials.
 


### PR DESCRIPTION
Spotted by Paul Wouters

> this doesn't parse:
>  This hash becomes the payload of a COSE-Sign1. When signed with a signature algorithm that is parameterized via a hash function, such as ECDSA with SHA384, the to be signed structure as described in Section 4.4 of RFC9052.
> 
> probably this was meant: as described -> is as described     