### PR TITLE
Remove EDN draft dependency

### DIFF
--- a/draft-ietf-cose-hash-envelope.md
+++ b/draft-ietf-cose-hash-envelope.md
@@ -121,7 +121,7 @@ The difference between content_type (3) and payload_preimage_content_type (259) 
 
 Profiles that rely on this specification MAY choose to mark 258, 259, 260 (or other header parameters) critical, see {{Section C.1.3 of RFC9052}} for more details.
 
-# Envelope CBOR diagnostic notation
+Envelope Extended Diagnostic Notation ({{Appendix G of RFC8610}}).
 
 The following informative example demonstrates how to construct a hash envelope for a resource already commonly referenced by its hash.
 


### PR DESCRIPTION
I propose removing this reference, because:

1. Paul Wouters pointed out:

> I don't think [I-D.draft-ietf-cbor-edn-literals] can be infornative if you use it in a section called "Terminology". I think it should be normative.

2. I don't think it adds anything over describing the sample as CBOR extended diagnostic notation, which is defined in in RFC8610, Appendix G, but it does create a dependency on a draft.