### PR TITLE
Update header for Envelope Extended Diagnostic Notation

### DIFF
--- a/draft-ietf-cose-hash-envelope.md
+++ b/draft-ietf-cose-hash-envelope.md
@@ -127,7 +127,7 @@ The difference between content_type (3) and payload_preimage_content_type (259) 
 
 Profiles that rely on this specification MAY choose to mark 258, 259, 260 (or other header parameters) critical. Refer to {{Section C.1.3 of RFC9052}} for an example of signature with criticality.
 
-Envelope Extended Diagnostic Notation ({{Appendix G of RFC8610}}).
+## Envelope Extended Diagnostic Notation ({{Appendix G of RFC8610}}).
 
 The following informative example demonstrates how to construct a hash envelope for a resource already commonly referenced by its hash.
 


### PR DESCRIPTION
Towards #59, I seem to have removed the header in error in https://github.com/cose-wg/draft-ietf-cose-hash-envelope/commit/d50693b5619f6061110d1531c8489b73303dbca8

I think it probably ought to be a sub-header though, please review. I am not clear on whether references in header titles are acceptable or not.