### PR TITLE
Drop unclear sentence from security considerations

### DIFF
--- a/draft-ietf-cose-hash-envelope.md
+++ b/draft-ietf-cose-hash-envelope.md
@@ -176,7 +176,6 @@ The resulting signature is computed over the protected header and payload, provi
 It is RECOMMENDED to align the strength of the chosen hash function to the strength of the chosen signature algorithm.
 For example, when signing with ECDSA using P-256 and SHA-256, use SHA-256 to hash the payload.
 Note that when using a pre-hash algorithm, the algorithm SHOULD be registered in the IANA COSE Algorithms registry, and should be distinguishable from non-pre hash variants that may also be present.
-The approach this specification takes is just one way to perform application-agnostic pre-hashing, meaning the pre hashing is not done with binding or consideration for a specific application context, while performing application (COSE) specific signing, meaning the to be signed bytes include the COSE structures necessary to distinguish a COSE signature from other digital signature formats.
 
 ## Encrypted Hashes
 


### PR DESCRIPTION
Towards #59, I've looked at https://github.com/cose-wg/draft-ietf-cose-hash-envelope/commit/0de0446a360005c57dc78230cabfd1bd5d6f7562 which introduced the sentence, but I cannot work out how either relates to Choice of Hash Function.

There are two points here:

1. The digest is over a an arbitrary message, and provides no explicit mechanism to include application context beyond a media type (258). It's not proscribed to use additional header params to do that though, this is no more or no less application specific than COSE.
2. COSE envelopes have a distinctive structure.

Neither point seems useful enough to make elsewhere in the document.