### PR TITLE
Clarify content_type and payload_preimage_content_type

### DIFF
--- a/draft-ietf-cose-hash-envelope.md
+++ b/draft-ietf-cose-hash-envelope.md
@@ -125,7 +125,7 @@ Hash_Envelope_Unprotected_Header = {
 Label `3` is easily confused with label `259` payload_preimage_content_type.
 The difference between content_type (3) and payload_preimage_content_type (259) is that content_type is used to identify the content format associated with payload, whereas payload_preimage_content_type is used to identify the content format of the bytes which are hashed to produce the payload.
 
-When the actual content is a bstr, a verifier contemplating a content-type bstr might ask itself if that described the digest bytes or the preimage bytes. With preimage-content-type set to bstr, it is clear that the preimage bytes themselves were a bstr.
+For example, when the actual content is a bstr, a Verifier appraising a content-type bstr has to decicde if that bstr describes the digest bytes or the preimage bytes. Setting preimage-content-type to bstr, makes it clear that the preimage bytes themselves were a bstr.
 
 Profiles that rely on this specification MAY choose to mark 258, 259, 260 (or other header parameters) critical. Refer to {{Section C.1.3 of RFC9052}} for an example of signature with criticality.
 


### PR DESCRIPTION
Clarify the distinction between content_type and payload_preimage_content_type, and explain the implications of using bstr for preimage bytes. Towards #63, but still needs a response to the reviewer.