### PR TITLE
Add Payload Verification section

### DIFF
--- a/draft-ietf-cose-hash-envelope.md
+++ b/draft-ietf-cose-hash-envelope.md
@@ -186,6 +186,10 @@ Note that when using a pre-hash algorithm, the algorithm SHOULD be registered in
 
 Only COSE_Sign/COSE_Sign1 and COSE_Mac/COSE_Mac0 are in scope for this document. COSE_Encrypt/COSE_Encrypt0 is out of the scope of this document.
 
+## Payload Verification
+
+If a payload-location is specified, a verifier can choose to fetch the content, and confirm that the digest of it, produced with the function defined by payload-hash-alg, matches the payload bytes. Verifiers that not have access to the internet and obtain the preimage via other means will not be able to perform that check, nor to derive utility from it.
+
 # IANA Considerations
 
 ## COSE Header Parameters


### PR DESCRIPTION
Added a section on payload verification to clarify how verifiers can confirm content integrity. Closes #64.